### PR TITLE
Bugfix: Bot not spinning

### DIFF
--- a/Released/code/base_bot.py
+++ b/Released/code/base_bot.py
@@ -1,6 +1,7 @@
 # *************************************************
 # Sumo Bot Firmware
 # *************************************************
+import random
 import time
 
 import analogio
@@ -95,6 +96,9 @@ class SumoBotBase:
 
         # Set initial state
         self.state = DISARMED
+
+        # Decide if bot will spin to the left or to the right
+        self.spin_right = bool(random.randint(0, 1))
 
     def run(self):
         """

--- a/Released/code/code.py
+++ b/Released/code/code.py
@@ -86,9 +86,9 @@ class SimpleSumoBot(SumoBotBase):
 
             # Spin and look for opponent
             else:
-                # Turn to the left or right randomly
+                # Turn to the left or right
                 print("Spinning")
-                if random.randint(0,1):
+                if self.spin_right:
                     self.drive(left_speed=-TURN_SPEED, right_speed=TURN_SPEED, duration=TURN_DURATION)
                 else:
                     self.drive(left_speed=TURN_SPEED, right_speed=-TURN_SPEED, duration=TURN_DURATION)

--- a/Released/code/settings.py
+++ b/Released/code/settings.py
@@ -25,7 +25,7 @@ MAX_SPEED = 0.7
 TURN_SPEED = 0.5
 
 # Turning duration in seconds when searching for opponent
-TURN_DURATON = 0.05
+TURN_DURATION = 0.05
 
 
 ##################################################


### PR DESCRIPTION
This PR fixes a bug I found in the latest version of the firmware: The bot was not spinning around to check for opponents because it was randomly choosing a direction to pivot each cycle. Now it chooses a direction at startup and consistently spins in that direction.